### PR TITLE
Patch for browsing and searching emails

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,7 +81,7 @@ def inbox(number):
     # Fetch last five messages until five messages are fetched
     # or message count goes to zero
     for i in range(uid_number, max(0, uid_number - 5), -1):
-        _, raw_data = inbox.fetch(str(i), "(RFC822)")
+        _, raw_data = inbox.fetch(str(i), "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM DATE)])")
         msg = parse_from_bytes(raw_data[0][1])
         msgs.append(msg)
         uids_str.append(i)
@@ -243,7 +243,7 @@ def search_process():
         # Adds to html text with five messages
         for i in range(-1, max(-6, -len(data) - 1), -1):
             uid = data[i].decode()
-            _, raw_data = mailbox.fetch(uid, "(BODY[HEADER.FIELDS (SUBJECT FROM DATE)])")
+            _, raw_data = mailbox.fetch(uid, "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM DATE)])")
             msg = parse_from_bytes(raw_data[0][1])
 
             link = url_for("inbox_message", uid=uid, inbox_page=0)
@@ -286,7 +286,7 @@ def search_next():
     # Adds to html text with next five messages
     for i in range(-1 - (5 * index), max(-6 - (5 * index), -len(uids) - 1), -1):
         uid = uids[i].decode()
-        _, raw_data = mailbox.fetch(uid, "(BODY[HEADER.FIELDS (SUBJECT FROM DATE)])")
+        _, raw_data = mailbox.fetch(uid, "(BODY.PEEK[HEADER.FIELDS (SUBJECT FROM DATE)])")
         msg = parse_from_bytes(raw_data[0][1])
 
         link = url_for("inbox_message", uid=uid, inbox_page=0)

--- a/app.py
+++ b/app.py
@@ -231,10 +231,10 @@ def search_process():
 
         # Returns "No messages found" if the query returns no messages
         if len(data) == 0:
-            return jsonify({"htmlText": "<p>No messages found</p>"})
+            return jsonify({"error": "No messages found"})
 
         # Store session info about search
-        session["search-index"] = 0
+        session["search-index"] = index = 0
         session["search-uid"] = data
 
         # HTML text
@@ -259,10 +259,13 @@ def search_process():
         # Close the connection
         mailbox.close()
         mailbox.logout()
+
+        can_next = not (abs(-1 - 5 * (index + 1)) > len(data))
         
-        return jsonify({"htmlText": html_text})
+        return jsonify({"htmlText": html_text, "canNext": can_next})
 
     return jsonify({"error": "Missing data!"})
+
 
 @app.route("/inbox/search/next", methods=["POST"])
 def search_next():
@@ -303,7 +306,7 @@ def search_next():
     # Update the index
     session["search-index"] = index
 
-    can_next = not (abs(-1 - 5 * (index + 1)) > len(uid))
+    can_next = not (abs(-1 - 5 * (index + 1)) > len(uids))
     can_prev = -1 - 5 * (index - 1) <= -1
 
     return jsonify({"htmlText": html_text, "canNext": can_next, "canPrev": can_prev})

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,3 +1,43 @@
+function setupText(uids) {
+    for (let i = 0; i < uids.length; i++) {
+        let uid = "#" + uids[i];
+
+        // When the user clicks on the link, text should show up
+        // below the message
+        $(uid).on("click", function (event) {
+            $.ajax({
+                data: {
+                    uid: uids[i]
+                },
+                type: "POST",
+                url: "/inbox/search/show"
+            })
+            .done(function (data) {
+                $(uid + "-text").html(data.text).show();
+
+                $(uid).off("click");
+                $(uid).on("click", function (event) {
+                    $(uid + "-text").toggle();
+                });
+            });
+
+            $(uid + "-text").text("...loading").show();
+        });
+    };
+};
+
+function handleData(data) {
+    if (data.error) {
+        $("main").hide();
+        $("#errorAlert").text(data.error).show();
+    } else {
+        $("main").html(data.htmlText).show();
+        $("#errorAlert").hide();
+        setupText(data.uids);
+    }
+    $("#loadingAlert").hide();
+}
+
 $(document).ready(function () {
     $("form").on("submit", function (event) {
         $.ajax({
@@ -8,17 +48,8 @@ $(document).ready(function () {
             url: "/inbox/search/process"
         })
         .done(function (data) {
-            if (data.error) {
-                $("main").hide();
-                $("#errorAlert").text(data.error).show();
-            } else {
-                $("main").html(data.htmlText).show();
-                $("#errorAlert").hide();
-                $("#next").text("Next").show();
-            }
-            $("#loadingAlert").hide();
+            handleData(data);
             $("#prev").hide();
-
             if (data.canNext) {
                 $("#next").text("Next").show();
             } else {
@@ -40,15 +71,7 @@ $(document).ready(function () {
             url: "/inbox/search/next"
         })
         .done(function (data) {
-            if (data.error) {
-                $("main").hide();
-                $("#errorAlert").text(data.error).show();
-            } else {
-                $("main").html(data.htmlText).show();
-                $("#errorAlert").hide();
-            }
-            $("#loadingAlert").hide();
-
+            handleData(data);
             if (!data.canNext) {
                 $("#next").hide();
             }
@@ -68,15 +91,7 @@ $(document).ready(function () {
             url: "/inbox/search/next"
         })
         .done(function (data) {
-            if (data.error) {
-                $("main").hide();
-                $("#errorAlert").text(data.error).show();
-            } else {
-                $("main").html(data.htmlText).show();
-                $("#errorAlert").hide();
-            }
-            $("#loadingAlert").hide();
-
+            handleData(data);
             if (!data.canPrev) {
                 $("#prev").hide();
             }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -12,14 +12,21 @@ $(document).ready(function () {
                 $("main").hide();
                 $("#errorAlert").text(data.error).show();
             } else {
-                $("main").html(data.htmlText);
+                $("main").html(data.htmlText).show();
                 $("#errorAlert").hide();
                 $("#next").text("Next").show();
             }
             $("#loadingAlert").hide();
             $("#prev").hide();
+
+            if (data.canNext) {
+                $("#next").text("Next").show();
+            } else {
+                $("#next").hide();
+            }
         });
 
+        $("#errorAlert").hide();
         $("#loadingAlert").text("...loading").show();
         event.preventDefault();
     });
@@ -37,7 +44,7 @@ $(document).ready(function () {
                 $("main").hide();
                 $("#errorAlert").text(data.error).show();
             } else {
-                $("main").html(data.htmlText);
+                $("main").html(data.htmlText).show();
                 $("#errorAlert").hide();
             }
             $("#loadingAlert").hide();
@@ -65,7 +72,7 @@ $(document).ready(function () {
                 $("main").hide();
                 $("#errorAlert").text(data.error).show();
             } else {
-                $("main").html(data.htmlText);
+                $("main").html(data.htmlText).show();
                 $("#errorAlert").hide();
             }
             $("#loadingAlert").hide();

--- a/templates/inbox.html
+++ b/templates/inbox.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Login Page{% endblock %}
+{% block title %}Inbox Page{% endblock %}
 {% block content %}
 <!-- TODO: Add nice layout for the inbox page -->
 <h1>Inbox</h1>

--- a/templates/inbox.html
+++ b/templates/inbox.html
@@ -29,7 +29,7 @@
   <a href="{{ url_for('inbox', number=0) }}">Newest</a>
   <a href="{{ url_for('inbox', number=number-1) }}">Previous</a>
   {% else %}
-  Latest
+  Newest
   Previous
   {% endif %}
 


### PR DESCRIPTION
I have created a patch for the development branch, and patch mainly deals with browsing and searching emails.

### Patch Notes
- Allow user to see text on their messages when they press the message subject on the search page
- Corrected the page title in the html head for the inbox page
- Corrected a typo from "latest" to "newest" in search page
- Optimized IMAP commands, preventing some messages to have their flags being set to seen.
- Fixed showing and hiding the next and previous links for search page
- Refactored code for fetching messages for the search feature